### PR TITLE
Implement automatic signature generation using signing secret

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -502,7 +502,7 @@ class Api
     public function generateSignature(string $url, ?array $parameters = null): string
     {
         $url = parse_url($url);
-        if (isset($parameters)) {
+        if (is_null($parameters)) {
             $url['query'] = http_build_query($parameters);
         }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -502,7 +502,8 @@ class Api
     public function generateSignature(string $url, ?array $parameters = null): string
     {
         $url = parse_url($url);
-        if (is_null($parameters)) {
+
+        if (!is_null($parameters)) {
             $url['query'] = http_build_query($parameters);
         }
 

--- a/tests/StreetViewAccessorsTest.php
+++ b/tests/StreetViewAccessorsTest.php
@@ -30,6 +30,12 @@ class StreetViewAccessorsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(get_class($result), Api::class);
     }
 
+    public function testSetSigningSecret()
+    {
+        $result = $this->streetView->setSigningSecret('');
+        $this->assertSame(get_class($result), Api::class);
+    }
+
     public function testSetImageWidth()
     {
         $result = $this->streetView->setImageWidth(42);

--- a/tests/StreetViewSigningTest.php
+++ b/tests/StreetViewSigningTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Defro\Google\StreetView\Tests;
+
+use Defro\Google\StreetView\Exception\UnexpectedValueException;
+use GuzzleHttp\Client;
+use Defro\Google\StreetView\Api;
+
+class StreetViewSigningTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGenerateSignatureFromUrl()
+    {
+        $streetView = new Api(new Client());
+        $streetView->setSigningSecret('aaa');
+        $result = $streetView->generateSignature('https://maps.googleapis.com/maps/api/streetview?location=test');
+        $this->assertSame($result, 'xkEwlZTZ83QCDJB3dL9yDRK8KRs=');
+    }
+
+    public function testGenerateSignatureFromUrlWithParameters()
+    {
+        $streetView = new Api(new Client());
+        $streetView->setSigningSecret('aaa');
+        $result = $streetView->generateSignature('https://maps.googleapis.com/maps/api/streetview', [
+            'location' => 'test'
+        ]);
+        $this->assertSame($result, 'xkEwlZTZ83QCDJB3dL9yDRK8KRs=');
+    }
+}


### PR DESCRIPTION
I've implemented a method setSigningSecret which allows for automatic generation of URL signatures using a signing secret. No changes have been made to existing behavior.