### PR TITLE
bump guzzlehttp/guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "ext-xdebug": "*",


### PR DESCRIPTION
Required for usage with Laravel 8 (cfr. https://laravel.com/docs/8.x/upgrade#updating-dependencies). The API is the same, and no other changes are required.